### PR TITLE
Correct the documented default for url input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ inputs:
     description: 'Config to generate checksum files.'
     required: false
   url:
-    description: 'Base Nexus url, defaults to "https://oss.sonatype.org"'
+    description: 'Base Nexus url, defaults to "https://s01.oss.sonatype.org"'
     required: false
   upload:
     description: 'Upload files, defaults to "false".'


### PR DESCRIPTION
Small follow-on from https://github.com/spring-io/nexus-sync-action/commit/70232ff8978e88aa65dc0975000c7206e04468fd.